### PR TITLE
ACTS v13.0.0 compatibility.

### DIFF
--- a/src/ACTSProcBase.cxx
+++ b/src/ACTSProcBase.cxx
@@ -108,8 +108,8 @@ void ACTSProcBase::buildDetector()
     // Set up the converter first
     Acts::MaterialMapJsonConverter::Config jsonGeoConvConfig;
     // Set up the json-based decorator
-    matDeco = std::make_shared<const Acts::JsonMaterialDecorator>(
-        jsonGeoConvConfig, _matFile);
+    matDeco = std::make_shared<const Acts::JsonMaterialDecorator>
+      (jsonGeoConvConfig, _matFile, Acts::Logging::INFO);
   }
 
   // configure surface array creator


### PR DESCRIPTION
Some updates to be compatible with ACTS v13.0.0 API.

- `Acts::JsonMaterialDector` now needs a log level.
- Unit changes in seeding parameters (now uses `Acts::UnitConstants`).
- `decltype(finder)::State` to pre-allocate memory for seed finding algorithm.
- `Acts::Seedfinder::createSeedsForGroup` now stores seed in an existing `std::vector` instead of returning the results.