### PR TITLE
Configuring layer detection envelope in ACTSProcBase.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v1.1.0 (upcoming)
 	- Fix paths for running ACTSTracking outside of a release.
+	- Remove dependance on custom ACTS by configuring layer detection envelope in ACTSProcBase.
 
 # v1.0.0
 	- Initial release.

--- a/src/ACTSProcBase.cxx
+++ b/src/ACTSProcBase.cxx
@@ -239,6 +239,7 @@ void ACTSProcBase::buildDetector()
       lConfig.volumeName = "VertexEndcap*";
       lConfig.sensorNames = {"sensor*"};
       lConfig.localAxes = "xZy";
+      lConfig.envelope = std::pair<double, double>(0.1 * Acts::UnitConstants::mm, 0.1 * Acts::UnitConstants::mm);
 
       // Fill the parsing restrictions in r
       lConfig.parseRanges.push_back({Acts::binR, {0, 120}});
@@ -259,6 +260,7 @@ void ACTSProcBase::buildDetector()
       lConfig.volumeName = "VertexBarrel*";
       lConfig.sensorNames = {"VertexBarrel_layer*_sens"};
       lConfig.localAxes = "YZX";
+      lConfig.envelope = std::pair<double, double>(0.1 * Acts::UnitConstants::mm, 0.1 * Acts::UnitConstants::mm);
 
       // Fill the parsing restrictions in r
       lConfig.parseRanges.push_back({Acts::binR, {0, 120}});
@@ -279,6 +281,7 @@ void ACTSProcBase::buildDetector()
       lConfig.volumeName = "VertexEndcap*";
       lConfig.sensorNames = {"sensor*"};
       lConfig.localAxes = "xZy";
+      lConfig.envelope = std::pair<double, double>(0.1 * Acts::UnitConstants::mm, 0.1 * Acts::UnitConstants::mm);
 
       // Fill the parsing restrictions in r
       lConfig.parseRanges.push_back({Acts::binR, {0, 120}});


### PR DESCRIPTION
This removes the need for a custom ACTS release where this configuration was hard-coded.