### PR TITLE
Update example seeding/CKF parameters to something that works with BIB.

### DIFF
--- a/example/actsseedckf_steer.xml
+++ b/example/actsseedckf_steer.xml
@@ -242,12 +242,12 @@ href="http://ilcsoft.desy.de/marlin/marlin.xsl"?
     <parameter name="SeedFinding_RMax" type="float">150</parameter>
     <parameter name="SeedFinding_DeltaRMin" type="float">5</parameter>
     <parameter name="SeedFinding_DeltaRMax" type="float">80</parameter>
-    <parameter name="SeedFinding_CollisionRegion" type="float">75</parameter>
+    <parameter name="SeedFinding_CollisionRegion" type="float">1</parameter>
     <parameter name="SeedFinding_RadLengthPerSeed" type="float">0.1</parameter>
     <parameter name="SeedFinding_SigmaScattering" type="float">50</parameter>
     <parameter name="SeedFinding_MinPt" type="float">500</parameter>
     <!-- CKF Configuration -->
-    <parameter name="CKF_Chi2CutOff" type="float">1</parameter>
+    <parameter name="CKF_Chi2CutOff" type="float">10</parameter>
     <parameter name="CKF_NumMeasurementsCutOff" type="int">1</parameter>
     <!--Define input tracker hits and relations. NB. Order must be respected -->
     <parameter name="TrackerHitCollectionNames" type="StringVec" lcioInType="TrackerHitPlane">

--- a/example/actstruthckf_steer.xml
+++ b/example/actstruthckf_steer.xml
@@ -236,7 +236,7 @@ href="http://ilcsoft.desy.de/marlin/marlin.xsl"?
     <!--Name of the MCParticle input collection-->
     <parameter name="MCParticleCollectionName" type="string" lcioInType="MCParticle">MCParticle </parameter>
     <!-- CKF Configuration -->
-    <parameter name="CKF_Chi2CutOff" type="float">1</parameter>
+    <parameter name="CKF_Chi2CutOff" type="float">10</parameter>
     <parameter name="CKF_NumMeasurementsCutOff" type="int">1</parameter>
     <!--Silicon track Collection Name-->
     <parameter name="TrackCollectionName" type="string" lcioOutType="Track">AllTracks</parameter>


### PR DESCRIPTION
The two changes are as follows, with [references to the following presentation](https://www.dropbox.com/s/hxu15bordxg2oxu/mcc-20210810.pdf?dl=0).

1) Increases the CKF search window from 1 chi2 to 10 chi2. This is why all tracks had a low track count. The window was just too small. You can see the effect of this on slide 11.

2) Decreases the "collision region" from 75 mm to 1 mm when finding seeds. Tightening this parameter significantly reduces the number of CKF seeds significantly. This was the key to get ACTS track reconstruction to complete within a few minutes. Also it is necessary for a good reconstruction efficiency. See slides 5-7.