### PR TITLE
Add subdetectorHitNumbers to EVENT::Track.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -14,15 +14,19 @@ IncludeCategories:
     Priority:        3
     SortPriority:    0
     CaseSensitive:   false
-  - Regex:           '^<UTIL/.*\.h>'
+  - Regex:           '^<IMPL/.*\.h>'
     Priority:        4
     SortPriority:    0
     CaseSensitive:   false
-  - Regex:           '^<.*'
+  - Regex:           '^<UTIL/.*\.h>'
     Priority:        5
     SortPriority:    0
     CaseSensitive:   false
-  - Regex:           '.*'
+  - Regex:           '^<.*'
     Priority:        6
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        7
     SortPriority:    0
     CaseSensitive:   false

--- a/.clang-format
+++ b/.clang-format
@@ -14,19 +14,23 @@ IncludeCategories:
     Priority:        3
     SortPriority:    0
     CaseSensitive:   false
-  - Regex:           '^<IMPL/.*\.h>'
+  - Regex:           '^<EVENT/.*\.h>'
     Priority:        4
     SortPriority:    0
     CaseSensitive:   false
-  - Regex:           '^<UTIL/.*\.h>'
+  - Regex:           '^<IMPL/.*\.h>'
     Priority:        5
     SortPriority:    0
     CaseSensitive:   false
-  - Regex:           '^<.*'
+  - Regex:           '^<UTIL/.*\.h>'
     Priority:        6
     SortPriority:    0
     CaseSensitive:   false
-  - Regex:           '.*'
+  - Regex:           '^<.*'
     Priority:        7
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        8
     SortPriority:    0
     CaseSensitive:   false

--- a/ACTSTracking/ACTSDuplicateRemoval.hxx
+++ b/ACTSTracking/ACTSDuplicateRemoval.hxx
@@ -2,6 +2,7 @@
 #define ACTSDuplicateRemoval_h 1
 
 #include <EVENT/Track.h>
+
 #include <marlin/Processor.h>
 
 //! \brief Remove track duplicates

--- a/ACTSTracking/ACTSSeededCKFTrackingProc.hxx
+++ b/ACTSTracking/ACTSSeededCKFTrackingProc.hxx
@@ -1,10 +1,11 @@
 #ifndef ACTSSeededCKFTrackingProc_h
 #define ACTSSeededCKFTrackingProc_h 1
 
+#include <EVENT/TrackerHit.h>
+
 #include <UTIL/CellIDDecoder.h>
 
 #include <Acts/Definitions/Units.hpp>
-#include <EVENT/TrackerHit.h>
 
 #include "ACTSProcBase.hxx"
 #include "GeometryIdSelector.hxx"

--- a/ACTSTracking/ACTSTruthCKFTrackingProc.hxx
+++ b/ACTSTracking/ACTSTruthCKFTrackingProc.hxx
@@ -1,10 +1,11 @@
 #ifndef ACTSTruthCKFTrackingProc_h
 #define ACTSTruthCKFTrackingProc_h 1
 
+#include <EVENT/TrackerHit.h>
+
 #include <UTIL/CellIDDecoder.h>
 
 #include <Acts/Definitions/Units.hpp>
-#include <EVENT/TrackerHit.h>
 
 #include "ACTSProcBase.hxx"
 

--- a/ACTSTracking/ACTSTruthTrackingProc.hxx
+++ b/ACTSTracking/ACTSTruthTrackingProc.hxx
@@ -1,10 +1,11 @@
 #ifndef ACTSTruthTrackingProc_h
 #define ACTSTruthTrackingProc_h 1
 
+#include <EVENT/TrackerHit.h>
+
 #include <UTIL/CellIDDecoder.h>
 
 #include <Acts/Definitions/Units.hpp>
-#include <EVENT/TrackerHit.h>
 
 #include "ACTSProcBase.hxx"
 

--- a/ACTSTracking/GeometryIdMappingTool.hxx
+++ b/ACTSTracking/GeometryIdMappingTool.hxx
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <UTIL/CellIDDecoder.h>
-
 #include <EVENT/SimTrackerHit.h>
 #include <EVENT/TrackerHit.h>
+
+#include <UTIL/CellIDDecoder.h>
+
 #include <unordered_map>
 
 namespace ACTSTracking {

--- a/ACTSTracking/Helpers.hxx
+++ b/ACTSTracking/Helpers.hxx
@@ -1,12 +1,13 @@
 #pragma once
 
+#include <EVENT/LCEvent.h>
+#include <EVENT/Track.h>
+#include <EVENT/TrackState.h>
+
 #include <Acts/EventData/TrackParameters.hpp>
 #include <Acts/MagneticField/MagneticFieldProvider.hpp>
 #include <Acts/TrackFinding/CombinatorialKalmanFilter.hpp>
 #include <Acts/TrackFitting/KalmanFitter.hpp>
-#include <EVENT/LCEvent.h>
-#include <EVENT/Track.h>
-#include <EVENT/TrackState.h>
 
 #include "SourceLink.hxx"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v1.1.0 (upcoming)
 	- Fix paths for running ACTSTracking outside of a release.
 	- Remove dependance on custom ACTS by configuring layer detection envelope in ACTSProcBase.
+    - Add subdetector hit numbers to Track object.
 
 # v1.0.0
 	- Initial release.

--- a/src/ACTSDuplicateRemoval.cxx
+++ b/src/ACTSDuplicateRemoval.cxx
@@ -1,8 +1,10 @@
 #include "ACTSDuplicateRemoval.hxx"
 
 #include <EVENT/LCCollection.h>
+
 #include <IMPL/LCCollectionVec.h>
 #include <IMPL/LCFlagImpl.h>
+
 #include <algorithm>
 
 namespace ACTSTracking {

--- a/src/ACTSSeededCKFTrackingProc.cxx
+++ b/src/ACTSSeededCKFTrackingProc.cxx
@@ -1,5 +1,14 @@
 #include "ACTSSeededCKFTrackingProc.hxx"
 
+#include <EVENT/MCParticle.h>
+#include <EVENT/SimTrackerHit.h>
+
+#include <IMPL/LCCollectionVec.h>
+#include <IMPL/LCFlagImpl.h>
+#include <IMPL/LCRelationImpl.h>
+#include <IMPL/TrackImpl.h>
+#include <IMPL/TrackerHitPlaneImpl.h>
+
 #include <UTIL/LCRelationNavigator.h>
 #include <UTIL/LCTrackerConf.h>
 
@@ -17,13 +26,6 @@
 #include <Acts/TrackFinding/MeasurementSelector.hpp>
 #include <Acts/TrackFitting/GainMatrixSmoother.hpp>
 #include <Acts/TrackFitting/GainMatrixUpdater.hpp>
-#include <EVENT/MCParticle.h>
-#include <EVENT/SimTrackerHit.h>
-#include <IMPL/LCCollectionVec.h>
-#include <IMPL/LCFlagImpl.h>
-#include <IMPL/LCRelationImpl.h>
-#include <IMPL/TrackImpl.h>
-#include <IMPL/TrackerHitPlaneImpl.h>
 
 using namespace Acts::UnitLiterals;
 

--- a/src/ACTSTruthCKFTrackingProc.cxx
+++ b/src/ACTSTruthCKFTrackingProc.cxx
@@ -1,5 +1,13 @@
 #include "ACTSTruthCKFTrackingProc.hxx"
 
+#include <EVENT/MCParticle.h>
+#include <EVENT/SimTrackerHit.h>
+
+#include <IMPL/LCCollectionVec.h>
+#include <IMPL/LCFlagImpl.h>
+#include <IMPL/LCRelationImpl.h>
+#include <IMPL/TrackerHitPlaneImpl.h>
+
 #include <UTIL/LCRelationNavigator.h>
 #include <UTIL/LCTrackerConf.h>
 
@@ -12,12 +20,6 @@
 #include <Acts/TrackFinding/MeasurementSelector.hpp>
 #include <Acts/TrackFitting/GainMatrixSmoother.hpp>
 #include <Acts/TrackFitting/GainMatrixUpdater.hpp>
-#include <EVENT/MCParticle.h>
-#include <EVENT/SimTrackerHit.h>
-#include <IMPL/LCCollectionVec.h>
-#include <IMPL/LCFlagImpl.h>
-#include <IMPL/LCRelationImpl.h>
-#include <IMPL/TrackerHitPlaneImpl.h>
 
 using namespace Acts::UnitLiterals;
 

--- a/src/ACTSTruthTrackingProc.cxx
+++ b/src/ACTSTruthTrackingProc.cxx
@@ -1,5 +1,14 @@
 #include "ACTSTruthTrackingProc.hxx"
 
+#include <EVENT/MCParticle.h>
+#include <EVENT/SimTrackerHit.h>
+
+#include <IMPL/LCCollectionVec.h>
+#include <IMPL/LCFlagImpl.h>
+#include <IMPL/LCRelationImpl.h>
+#include <IMPL/TrackImpl.h>
+#include <IMPL/TrackerHitPlaneImpl.h>
+
 #include <UTIL/LCRelationNavigator.h>
 #include <UTIL/LCTrackerConf.h>
 
@@ -9,13 +18,6 @@
 #include <Acts/TrackFitting/GainMatrixSmoother.hpp>
 #include <Acts/TrackFitting/GainMatrixUpdater.hpp>
 #include <Acts/TrackFitting/KalmanFitter.hpp>
-#include <EVENT/MCParticle.h>
-#include <EVENT/SimTrackerHit.h>
-#include <IMPL/LCCollectionVec.h>
-#include <IMPL/LCFlagImpl.h>
-#include <IMPL/LCRelationImpl.h>
-#include <IMPL/TrackImpl.h>
-#include <IMPL/TrackerHitPlaneImpl.h>
 
 using namespace Acts::UnitLiterals;
 

--- a/src/Helpers.cxx
+++ b/src/Helpers.cxx
@@ -1,10 +1,11 @@
 #include "Helpers.hxx"
 
+#include <IMPL/TrackImpl.h>
+#include <IMPL/TrackStateImpl.h>
 
 #include <UTIL/CellIDDecoder.h>
 #include <UTIL/LCTrackerConf.h>
-#include <IMPL/TrackImpl.h>
-#include <IMPL/TrackStateImpl.h>
+
 #include <filesystem>
 
 #include "config.h"
@@ -107,14 +108,15 @@ EVENT::Track* ACTS2Marlin_track(
   std::reverse(statesOnTrack.begin(), statesOnTrack.end());
 
   // Save hits
-  UTIL::CellIDDecoder<lcio::TrackerHit> decoder(lcio::LCTrackerCellID::encoding_string());
+  UTIL::CellIDDecoder<lcio::TrackerHit> decoder(
+      lcio::LCTrackerCellID::encoding_string());
   EVENT::IntVec& subdetectorHitNumbers = track->subdetectorHitNumbers();
   for (EVENT::TrackerHit* hit : hitsOnTrack) {
     track->addHit(hit);
 
-    uint32_t sysid=decoder(hit)["system"];
-    if(subdetectorHitNumbers.size() <= sysid) {
-      subdetectorHitNumbers.resize(sysid+1,0);
+    uint32_t sysid = decoder(hit)["system"];
+    if (subdetectorHitNumbers.size() <= sysid) {
+      subdetectorHitNumbers.resize(sysid + 1, 0);
     }
     subdetectorHitNumbers[sysid]++;
   }

--- a/src/Helpers.cxx
+++ b/src/Helpers.cxx
@@ -1,5 +1,8 @@
 #include "Helpers.hxx"
 
+
+#include <UTIL/CellIDDecoder.h>
+#include <UTIL/LCTrackerConf.h>
 #include <IMPL/TrackImpl.h>
 #include <IMPL/TrackStateImpl.h>
 #include <filesystem>
@@ -104,8 +107,16 @@ EVENT::Track* ACTS2Marlin_track(
   std::reverse(statesOnTrack.begin(), statesOnTrack.end());
 
   // Save hits
+  UTIL::CellIDDecoder<lcio::TrackerHit> decoder(lcio::LCTrackerCellID::encoding_string());
+  EVENT::IntVec& subdetectorHitNumbers = track->subdetectorHitNumbers();
   for (EVENT::TrackerHit* hit : hitsOnTrack) {
     track->addHit(hit);
+
+    uint32_t sysid=decoder(hit)["system"];
+    if(subdetectorHitNumbers.size() <= sysid) {
+      subdetectorHitNumbers.resize(sysid+1,0);
+    }
+    subdetectorHitNumbers[sysid]++;
   }
 
   // Save the track states at hits

--- a/src/TrackTruthProc.cxx
+++ b/src/TrackTruthProc.cxx
@@ -1,11 +1,12 @@
 #include "TrackTruthProc.hxx"
 
-#include <UTIL/LCRelationNavigator.h>
-
 #include <EVENT/MCParticle.h>
 #include <EVENT/SimTrackerHit.h>
 #include <EVENT/Track.h>
+
 #include <IMPL/LCCollectionVec.h>
+
+#include <UTIL/LCRelationNavigator.h>
 
 #include "Helpers.hxx"
 


### PR DESCRIPTION
Adds the subdetector hit count to the track object. This can then propagate this information for further processing using files that don't include all of the hits themselves.

The index of the `subdetectorHitNumbers` property is the "system" part of the hit's cell ID.