### PR TITLE
Extrapolation to calo surface

### DIFF
--- a/ACTSTracking/ACTSSeededCKFTrackingProc.hxx
+++ b/ACTSTracking/ACTSSeededCKFTrackingProc.hxx
@@ -60,6 +60,10 @@ class ACTSSeededCKFTrackingProc : public ACTSProcBase {
   bool _runCKF = true;
   bool _propagateBackward = false;
 
+  // Extrapolation to calo settings
+  float _caloFaceR = 1857; //mm
+  float _caloFaceZ = 2307; //mm
+
   // Seed finding configuration
   float _seedFinding_rMax = 150;
   float _seedFinding_deltaRMin = 5;

--- a/ACTSTracking/Helpers.hxx
+++ b/ACTSTracking/Helpers.hxx
@@ -83,6 +83,11 @@ EVENT::Track* ACTS2Marlin_track(
     std::shared_ptr<Acts::MagneticFieldProvider> magneticField,
     Acts::MagneticFieldProvider::Cache& magCache);
 
+EVENT::Track* ACTS2Marlin_track(
+    const TrackResult& fitter_res,
+    std::shared_ptr<Acts::MagneticFieldProvider> magneticField,
+    Acts::MagneticFieldProvider::Cache& magCache, double caloFaceR, double caloFaceZ, Acts::GeometryContext geoContext, Acts::MagneticFieldContext magFieldContext, std::shared_ptr<const Acts::TrackingGeometry> trackingGeo);
+
 //! Convert ACTS track state class to Marlin class
 /**
  * \param location Location where the track state is defined (ie: `AtIP`)

--- a/src/ACTSSeededCKFTrackingProc.cxx
+++ b/src/ACTSSeededCKFTrackingProc.cxx
@@ -27,10 +27,6 @@
 #include <Acts/TrackFitting/GainMatrixSmoother.hpp>
 #include <Acts/TrackFitting/GainMatrixUpdater.hpp>
 
-#include <Acts/Surfaces/CylinderSurface.hpp>
-#include <Acts/Definitions/Algebra.hpp>
-#include <Acts/EventData/ParticleHypothesis.hpp>
-
 using namespace Acts::UnitLiterals;
 
 #include "Helpers.hxx"
@@ -693,51 +689,9 @@ void ACTSSeededCKFTrackingProc::processEvent(LCEvent *evt) {
           streamlog_out(DEBUG)
               << "\tnStates       " << trackTip.nTrackStates() << std::endl;
 
-          //FM: attempt at propagating to calo surface
-          double radius = _caloFaceR * Acts::UnitConstants::mm; // Radius in mm
-          double halfLength = _caloFaceZ * Acts::UnitConstants::mm; // Half-height in mm
-
-          // Create the CaloSurface
-          auto caloCylinder = std::make_shared<Acts::CylinderBounds>(radius, halfLength);
-          auto caloSurface = Acts::Surface::makeShared<Acts::CylinderSurface>(Acts::Transform3::Identity(), caloCylinder);
-
-          streamlog_out(DEBUG) <<  "Created the calo cylindrical surface" << std::endl;
-
-          // define start parameters - swap this out with some smart call
-          Acts::BoundVector params = trackTip.parameters();
-          double d0 = params[Acts::eBoundLoc0];
-          double z0 = params[Acts::eBoundLoc1];
-          double phi = params[Acts::eBoundPhi];
-          double theta = params[Acts::eBoundTheta];
-          double qoverp = params[Acts::eBoundQOverP];
-          double time = params[Acts::eBoundTime];
-
-          Acts::Vector3 pos(d0 * cos(phi), d0 * sin(phi), z0);
-          Acts::BoundMatrix cov = trackTip.covariance();
-
-          Acts::CurvilinearTrackParameters start(Acts::VectorHelpers::makeVector4(pos, time), phi, theta, qoverp, cov, Acts::ParticleHypothesis::pion());
-          streamlog_out(DEBUG) << "Retrieved the start track parameters" << std::endl;
-          
-          // Set propagator options
-          Acts::PropagatorOptions myCaloPropOptions(geometryContext(), magneticFieldContext());
-          myCaloPropOptions.pathLimit = 20 * Acts::UnitConstants::m;
-          std::cout << "init prop option" << std::endl;
-          
-          auto resultProp = propagator.propagate(start, *caloSurface, myCaloPropOptions);
-          if (resultProp.ok()) {
-            std::cout << "Good!" << std::endl;
-            //FM: should read back the result of the propagation? 
-            std::cout << "CaloPhi:" << phi << " " << resultProp.value().endParameters->parameters()[Acts::eBoundPhi] << std::endl;
-            // FM the line below is not correct, but it's what I'd like to do
-            //trackTip.addTrackState(result);
-          }
-          else {
-            std::cout << "Propagation failed" << std::endl;
-          }
-
           // Make track object
           EVENT::Track *track = ACTSTracking::ACTS2Marlin_track(
-              trackTip, magneticField(), magCache);
+              trackTip, magneticField(), magCache, _caloFaceR, _caloFaceZ, geometryContext(), magneticFieldContext(), trackingGeometry());
 
           // Save results
           trackCollection->addElement(track);

--- a/src/Helpers.cxx
+++ b/src/Helpers.cxx
@@ -389,7 +389,6 @@ EVENT::Track* ACTS2Marlin_track(
   // Set propagator options
   Acts::PropagatorOptions myCaloPropOptions(geoContext, magFieldContext);
   myCaloPropOptions.pathLimit = 20 * Acts::UnitConstants::m;
-  std::cout << "init prop option" << std::endl;
 
   //Let's try with our private propagator
   // Configurations
@@ -402,9 +401,9 @@ EVENT::Track* ACTS2Marlin_track(
   Stepper stepper(magneticField);
   Navigator navigator(navigatorCfg);
   Propagator mypropagator(std::move(stepper), std::move(navigator));
-  auto end_parameters = mypropagator.propagate(start, *caloSurface, myCaloPropOptions).value().endParameters;
-  if (end_parameters.has_value()) {
-    std::cout << "CaloPhi:" << phi << " " << end_parameters->parameters()[Acts::eBoundPhi] << std::endl;
+  auto resultProp = mypropagator.propagate(start, *caloSurface, myCaloPropOptions);
+  if (resultProp.ok()) {
+    auto end_parameters = resultProp.value().endParameters;
     const Acts::BoundMatrix& atCaloCovariance = *(end_parameters->covariance());
 
     EVENT::TrackState* trackStateAtCalo = ACTSTracking::ACTS2Marlin_trackState(
@@ -415,7 +414,6 @@ EVENT::Track* ACTS2Marlin_track(
     std::cout << "Failed propagation!" << std::endl;
   }
   
-
   std::reverse(hitsOnTrack.begin(), hitsOnTrack.end());
   std::reverse(statesOnTrack.begin(), statesOnTrack.end());
 


### PR DESCRIPTION
This PR adds the extrapolation of the tracks to the calorimeter surface.

This is still work in progress:
- the code compiles
- the addition of the track state at the calorimeter surface to the track is still missing
- crashes at run time on the call to the propagator with a "TUnixSystem::Di...  FATAL segmentation violation"

I am creating this ahead of time since I'll have now a couple of busy days, in case superexperts like @kkrizka @spagangriso or @pandreetto get a chance to take a look.

