### PR TITLE
Porting v32

### DIFF
--- a/ACTSTracking/ACTSTruthCKFTrackingProc.hxx
+++ b/ACTSTracking/ACTSTruthCKFTrackingProc.hxx
@@ -58,6 +58,10 @@ class ACTSTruthCKFTrackingProc : public ACTSProcBase {
   uint32_t _eventNumber;
   uint32_t _runNumber;
 
+  // Extrapolation to calo settings
+  float _caloFaceR = 1857; //mm
+  float _caloFaceZ = 2307; //mm
+
   // Track fit parameters
   double _initialTrackError_d0 = 20 * Acts::UnitConstants::um;  // Marlin: 1.e3
   double _initialTrackError_phi =

--- a/ACTSTracking/ACTSTruthTrackingProc.hxx
+++ b/ACTSTracking/ACTSTruthTrackingProc.hxx
@@ -74,6 +74,10 @@ class ACTSTruthTrackingProc : public ACTSProcBase {
   uint32_t _eventNumber;
   uint32_t _runNumber;
 
+  // Extrapolation to calo settings
+  float _caloFaceR = 1857; //mm
+  float _caloFaceZ = 2307; //mm
+
   // Track fit parameters
   double _initialTrackError_d0 = 20 * Acts::UnitConstants::um;  // Marlin: 1.e3
   double _initialTrackError_phi =

--- a/ACTSTracking/Helpers.hxx
+++ b/ACTSTracking/Helpers.hxx
@@ -78,15 +78,14 @@ EVENT::Track* ACTS2Marlin_track(
     std::shared_ptr<Acts::MagneticFieldProvider> magneticField,
     Acts::MagneticFieldProvider::Cache& magCache);
 */
-EVENT::Track* ACTS2Marlin_track(
-    const TrackResult& fitter_res,
-    std::shared_ptr<Acts::MagneticFieldProvider> magneticField,
-    Acts::MagneticFieldProvider::Cache& magCache);
 
 EVENT::Track* ACTS2Marlin_track(
     const TrackResult& fitter_res,
     std::shared_ptr<Acts::MagneticFieldProvider> magneticField,
-    Acts::MagneticFieldProvider::Cache& magCache, double caloFaceR, double caloFaceZ, Acts::GeometryContext geoContext, Acts::MagneticFieldContext magFieldContext, std::shared_ptr<const Acts::TrackingGeometry> trackingGeo);
+    Acts::MagneticFieldProvider::Cache& magCache,
+    double caloFaceR, double caloFaceZ, Acts::GeometryContext geoContext,
+    Acts::MagneticFieldContext magFieldContext,
+    std::shared_ptr<const Acts::TrackingGeometry> trackingGeo);
 
 //! Convert ACTS track state class to Marlin class
 /**


### PR DESCRIPTION
Numbers of hits per subdetectors are required by FilterTracks processor.
The method ACTS2Marlin_track without extrapolation to the calorimeter can be removed