### PR TITLE
Loading of layer description from JSON.

### DIFF
--- a/ACTSTracking/ACTSProcBase.hxx
+++ b/ACTSTracking/ACTSProcBase.hxx
@@ -61,7 +61,10 @@ class ACTSProcBase : public marlin::Processor {
   std::string _matFile{};
 
   //! Path to tracker geometry file
-  std::string _tgeoFile{};
+  std::string _tgeoFile = "data/MuColl_v1.root";
+
+  //! Path to tracker geometry json file
+  std::string _tgeodescFile = "data/MuColl_v1.json";
 
   std::shared_ptr<ACTSTracking::GeometryIdMappingTool> geoIDMappingTool() const;
 

--- a/data/MuColl_v1.json
+++ b/data/MuColl_v1.json
@@ -1,0 +1,307 @@
+{
+    "geo-tgeo-unit-scalor": 10.0,
+    "geo-tgeo-build-beampipe": false,
+    "geo-tgeo-beampipe-parameters": [
+	0.0,
+	0.0,
+	0.0
+    ],
+    "Volumes": [
+	{
+	    "geo-tgeo-volume-name": "Vertex",
+	    "geo-tgeo-sfbin-r-tolerance": {
+		"lower": 5.0,
+		"upper": 5.0
+	    },
+	    "geo-tgeo-sfbin-z-tolerance": {
+		"lower": 5.0,
+		"upper": 5.0
+	    },
+	    "geo-tgeo-sfbin-phi-tolerance": {
+		"lower": 0.025,
+		"upper": 0.025
+	    },
+	    "geo-tgeo-volume-layers": {
+		"negative": true,
+		"central": true,
+		"positive": true
+	    },
+	    "geo-tgeo-subvolume-names": {
+		"negative": "VertexEndcap*",
+		"central": "VertexBarrel*",
+		"positive": "VertexEndcap*"
+	    },
+	    "geo-tgeo-sensitive-names": {
+		"negative": ["sensor*"],
+		"central": ["VertexBarrel_layer*_sens"],
+		"positive": ["sensor*"]
+	    },
+	    "geo-tgeo-sensitive-axes": {
+		"negative": "xZy",
+		"central": "YZX",
+		"positive": "xZy"
+	    },
+	    "geo-tgeo-layer-r-ranges": {
+		"negative": {
+		    "lower": 0.0,
+		    "upper": 120.0
+		},
+		"central": {
+		    "lower": 0.0,
+		    "upper": 120.0
+		},
+		"positive": {
+		    "lower": 0.0,
+		    "upper": 120.0
+		}
+	    },
+	    "geo-tgeo-layer-z-ranges": {
+		"negative": {
+		    "lower": -285.0,
+		    "upper": -70.0
+		},
+		"central": {
+		    "lower": -70.0,
+		    "upper": 70.0
+		},
+		"positive": {
+		    "lower": 70.0,
+		    "upper": 285.0
+		}
+	    },
+	    "geo-tgeo-layer-r-split": {
+		"negative": -1.0,
+		"central": 0.1,
+		"positive": -1.0
+	    },
+	    "geo-tgeo-layer-z-split": {
+		"negative": 1.0,
+		"central": -1.0,
+		"positive": 1.0
+	    },
+	    "geo-tgeo-cyl-disc-split": false
+	},
+	{
+	    "geo-tgeo-volume-name": "InnerTrackers",
+	    "geo-tgeo-sfbin-r-tolerance": {
+		"lower": 5.0,
+		"upper": 5.0
+	    },
+	    "geo-tgeo-sfbin-z-tolerance": {
+		"lower": 5.0,
+		"upper": 5.0
+	    },
+	    "geo-tgeo-sfbin-phi-tolerance": {
+		"lower": 0.025,
+		"upper": 0.025
+	    },
+	    "geo-tgeo-volume-layers": {
+		"negative": true,
+		"central": true,
+		"positive": true
+	    },
+	    "geo-tgeo-subvolume-names": {
+		"negative": "InnerTrackerEndcap*",
+		"central": "InnerTrackerBarrel*",
+		"positive": "InnerTrackerEndcap*"
+	    },
+	    "geo-tgeo-sensitive-names": {
+		"negative": ["sensor*"],
+		"central": ["sensor*"],
+		"positive": ["sensor*"]
+	    },
+	    "geo-tgeo-sensitive-axes": {
+		"negative": "XYZ",
+		"central": "XYZ",
+		"positive": "XYZ"
+	    },
+	    "geo-tgeo-layer-r-ranges": {
+		"negative": {
+		    "lower": 50.0,
+		    "upper": 500.0
+		},
+		"central": {
+		    "lower": 120.0,
+		    "upper": 500.0
+		},
+		"positive": {
+		    "lower": 50.0,
+		    "upper": 500.0
+		}
+	    },
+	    "geo-tgeo-layer-z-ranges": {
+		"negative": {
+		    "lower": -600.0,
+		    "upper": -500.0
+		},
+		"central": {
+		    "lower": -500.0,
+		    "upper": 500.0
+		},
+		"positive": {
+		    "lower": 500.0,
+		    "upper": 600.0
+		}
+	    },
+	    "geo-tgeo-layer-r-split": {
+		"negative": -1.0,
+		"central": 10,
+		"positive": -1.0
+	    },
+	    "geo-tgeo-layer-z-split": {
+		"negative": 10.0,
+		"central": -1.0,
+		"positive": 10.0
+	    },
+	    "geo-tgeo-cyl-disc-split": false
+	},
+	{
+	    "geo-tgeo-volume-name": "OuterInnerTrackers",
+	    "geo-tgeo-sfbin-r-tolerance": {
+		"lower": 5.0,
+		"upper": 5.0
+	    },
+	    "geo-tgeo-sfbin-z-tolerance": {
+		"lower": 5.0,
+		"upper": 5.0
+	    },
+	    "geo-tgeo-sfbin-phi-tolerance": {
+		"lower": 0.025,
+		"upper": 0.025
+	    },
+	    "geo-tgeo-volume-layers": {
+		"negative": true,
+		"central": true,
+		"positive": true
+	    },
+	    "geo-tgeo-subvolume-names": {
+		"negative": "InnerTrackerEndcap*",
+		"central": "InnerTrackerBarrel*",
+		"positive": "InnerTrackerEndcap*"
+	    },
+	    "geo-tgeo-sensitive-names": {
+		"negative": ["sensor*"],
+		"central": ["sensor*"],
+		"positive": ["sensor*"]
+	    },
+	    "geo-tgeo-sensitive-axes": {
+		"negative": "XYZ",
+		"central": "XYZ",
+		"positive": "XYZ"
+	    },
+	    "geo-tgeo-layer-r-ranges": {
+		"negative": {
+		    "lower": 120.0,
+		    "upper": 600.0
+		},
+		"central": {
+		    "lower": 500.0,
+		    "upper": 600.0
+		},
+		"positive": {
+		    "lower": 120.0,
+		    "upper": 600.0
+		}
+	    },
+	    "geo-tgeo-layer-z-ranges": {
+		"negative": {
+		    "lower": -2210.0,
+		    "upper": -750.0
+		},
+		"central": {
+		    "lower": -750.0,
+		    "upper": 750.0
+		},
+		"positive": {
+		    "lower": 750.0,
+		    "upper": 2210.0
+		}
+	    },
+	    "geo-tgeo-layer-r-split": {
+		"negative": -1.0,
+		"central": 10,
+		"positive": -1.0
+	    },
+	    "geo-tgeo-layer-z-split": {
+		"negative": 10.0,
+		"central": -1.0,
+		"positive": 10.0
+	    },
+	    "geo-tgeo-cyl-disc-split": false
+	},
+	{
+	    "geo-tgeo-volume-name": "OuterTrackers",
+	    "geo-tgeo-sfbin-r-tolerance": {
+		"lower": 5.0,
+		"upper": 5.0
+	    },
+	    "geo-tgeo-sfbin-z-tolerance": {
+		"lower": 5.0,
+		"upper": 5.0
+	    },
+	    "geo-tgeo-sfbin-phi-tolerance": {
+		"lower": 0.025,
+		"upper": 0.025
+	    },
+	    "geo-tgeo-volume-layers": {
+		"negative": true,
+		"central": true,
+		"positive": true
+	    },
+	    "geo-tgeo-subvolume-names": {
+		"negative": "OuterTrackerEndcap*",
+		"central": "OuterTrackerBarrel*",
+		"positive": "OuterTrackerEndcap*"
+	    },
+	    "geo-tgeo-sensitive-names": {
+		"negative": ["sensor*"],
+		"central": ["sensor*"],
+		"positive": ["sensor*"]
+	    },
+	    "geo-tgeo-sensitive-axes": {
+		"negative": "XYZ",
+		"central": "XYZ",
+		"positive": "XYZ"
+	    },
+	    "geo-tgeo-layer-r-ranges": {
+		"negative": {
+		    "lower": 570.0,
+		    "upper": 1550.0
+		},
+		"central": {
+		    "lower": 600.0,
+		    "upper": 1550.0
+		},
+		"positive": {
+		    "lower": 570.0,
+		    "upper": 1550.0
+		}
+	    },
+	    "geo-tgeo-layer-z-ranges": {
+		"negative": {
+		    "lower": -2210.0,
+		    "upper": -1300.0
+		},
+		"central": {
+		    "lower": -1300.0,
+		    "upper": 1300.0
+		},
+		"positive": {
+		    "lower": 1300.0,
+		    "upper": 2210.0
+		}
+	    },
+	    "geo-tgeo-layer-r-split": {
+		"negative": -1.0,
+		"central": 10,
+		"positive": -1.0
+	    },
+	    "geo-tgeo-layer-z-split": {
+		"negative": 10.0,
+		"central": -1.0,
+		"positive": 10.0
+	    },
+	    "geo-tgeo-cyl-disc-split": false
+	}
+    ]
+}


### PR DESCRIPTION
The description of the tracking detector volumes and layers is now moved to an external JSON file instead of being hardcoded to the `MuColl_v1` geometry. The format of the JSON file is the same as used by the ACTS TGeo example as the [ACTSMCC instructions for generating material maps](https://mcd-wiki.web.cern.ch/software/howto/acts_geo/).

The processors that use the geometry now take a `TGeoDescFile` attribute with the path to the JSON file. For backwards compatibility, the default is set to the newly included `data/MuColl_v1.json`.

This does not remove all hardcoded dependence on `MuColl_v1` as the mapping tool (`GeometryIdMappingTool`) still needs to be configurable.