### PR TITLE
Fix particle hypothesis having to be positive in truth tracking.

### DIFF
--- a/ACTSTracking/Helpers.hxx
+++ b/ACTSTracking/Helpers.hxx
@@ -113,7 +113,16 @@ EVENT::TrackState* ACTS2Marlin_trackState(int location,
 EVENT::LCCollection* getCollection(EVENT::LCEvent* evt,
                                    const std::string& name);
 
-Acts::ParticleHypothesis convertParticle(const EVENT::MCParticle* mcParticle);
+//! Get particle hypothesis for a given MCParticle object
+/**
+ * The particle hypothesis is determined by the PDG code of the MCParticle. The
+ * absolute value is taken, as this is a requirement from ACTS.
+ *
+ * \param mcParticle MCParticle object for which to determine a hypothesis
+ *
+ * \return The ACTS particle hypothesis
+ */
+Acts::ParticleHypothesis getParticleHypothesis(const EVENT::MCParticle* mcParticle);
 
 }  // namespace ACTSTracking
 

--- a/src/ACTSTruthCKFTrackingProc.cxx
+++ b/src/ACTSTruthCKFTrackingProc.cxx
@@ -152,7 +152,7 @@ void ACTSTruthCKFTrackingProc::processEvent(LCEvent* evt) {
         std::pow(_initialTrackError_relP * p / (p * p), 2);
 
     Acts::BoundTrackParameters seed(perigeeSurface, params, cov,
-                                    ACTSTracking::convertParticle(mcParticle));
+                                    ACTSTracking::getParticleHypothesis(mcParticle));
     seeds.push_back(seed);
   }
 

--- a/src/ACTSTruthTrackingProc.cxx
+++ b/src/ACTSTruthTrackingProc.cxx
@@ -332,7 +332,7 @@ void ACTSTruthTrackingProc::processEvent(LCEvent* evt) {
             Acts::Vector3(mcParticle->getVertex()));
 
     Acts::BoundTrackParameters initialparams(perigeeSurface, params,
-                                             cov, ACTSTracking::convertParticle(mcParticle));
+                                             cov, ACTSTracking::getParticleHypothesis(mcParticle));
     // reference Examples TruthTracking/ParticleSmearing.cpp
     streamlog_out(DEBUG) << "Initial Paramemeters" << std::endl
                          << initialparams << std::endl;

--- a/src/Helpers.cxx
+++ b/src/Helpers.cxx
@@ -502,37 +502,25 @@ EVENT::LCCollection* getCollection(EVENT::LCEvent* evt,
   }
 }
 
-Acts::ParticleHypothesis convertParticle(const EVENT::MCParticle* mcParticle)
+Acts::ParticleHypothesis getParticleHypothesis(const EVENT::MCParticle* mcParticle)
 {
-  switch (mcParticle->getPDG()) {
+  switch (std::abs(mcParticle->getPDG())) {
   case 11:
     return Acts::ParticleHypothesis {Acts::PdgParticle::eElectron};
-  case -11:
-    return Acts::ParticleHypothesis {Acts::PdgParticle::ePositron};
   case 13:
     return Acts::ParticleHypothesis {Acts::PdgParticle::eMuon};
-  case -13:
-    return Acts::ParticleHypothesis {Acts::PdgParticle::eAntiMuon};
   case 15:
     return Acts::ParticleHypothesis {Acts::PdgParticle::eTau};
-  case -15:
-    return Acts::ParticleHypothesis {Acts::PdgParticle::eAntiTau};
   case 22:
     return Acts::ParticleHypothesis {Acts::PdgParticle::eGamma};
   case 111:
     return Acts::ParticleHypothesis {Acts::PdgParticle::ePionZero};
   case 211:
     return Acts::ParticleHypothesis {Acts::PdgParticle::ePionPlus};
-  case -211:
-    return Acts::ParticleHypothesis {Acts::PdgParticle::ePionMinus};
   case 2112:
     return Acts::ParticleHypothesis {Acts::PdgParticle::eNeutron};
-  case -2112:
-    return Acts::ParticleHypothesis {Acts::PdgParticle::eAntiNeutron};
   case 2212:
     return Acts::ParticleHypothesis {Acts::PdgParticle::eProton};
-  case -2212:
-    return Acts::ParticleHypothesis {Acts::PdgParticle::eAntiProton};
   }
 
   Acts::PdgParticle pdg = Acts::PdgParticle::eInvalid;


### PR DESCRIPTION
I had the truth-based tracking (either full truth or truth ckf) fail with the following error:

```
[ MESSAGE "EventNumber"]  ===== Run  :       1  Event:       0
Marlin: /opt/spack/opt/spack/linux-almalinux9-x86_64/gcc-11.3.1/acts-32.1.0-xyo4rjih3ae4dvy3mgyi4wayju6fme63/include/Acts/EventData/GenericParticleHypothesis.hpp:52: Acts::GenericParticleHypothesis<charge_t>::GenericParticleHypothesis(Acts::PdgParticle) [with charge_t = Acts::AnyCharge]: Assertion `absPdg == makeAbsolutePdgParticle(absPdg) && "pdg is expected to be absolute"' failed.
Aborted
```

Appears that ACTS requires the particle hypothesis to always correspond to original (? not anti-) variation of the particle. This fixes it by taking the absolute value of the `MCParticle` PDG before creating the hypothesis.

The `convertParticle` function has been renamed to `getParticleHypothesis` to indicate that this is no longer a simple event data model conversion. The PDG ID does change.