### PR TITLE
Add missing ACTS extensions to ACTSTruthTrackingProc.

### DIFF
--- a/ACTSTracking/SourceLink.hxx
+++ b/ACTSTracking/SourceLink.hxx
@@ -65,5 +65,16 @@ struct SourceLinkAccessor : GeometryIdMultisetAccessor<SourceLink> {
   }
 };
 
+/// Access for the surface associated to a source link
+struct SurfaceAccessor {
+  const std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry;
+
+  const Acts::Surface* operator()(const Acts::SourceLink& sourceLink) const {
+    const auto& mySourceLink = sourceLink.get<SourceLink>();
+      return trackingGeometry->findSurface(mySourceLink.geometryId());
+    }
+  };
+
+
 }  // namespace ACTSTracking
 


### PR DESCRIPTION
The following extensions were missing in `ACTSTruthTrackingProc` and causing a crash at runtime:

- `extensions.calibrator.connect`: Used existing `ACTSTracking::MeasurementCalibrator`
- `extensions.surfaceAccessor`: Added a new `struct` that does a geoID looking in the ACTS tracking geometry to retrieve the corresponding surface. Based on `IndexSourceLink::SurfaceAccessor` in ACTS.